### PR TITLE
Fix cancelled Flows after thrown exception during first app launch & being in offline mode

### DIFF
--- a/app/src/main/java/com/example/uistateplayground/core/Result.kt
+++ b/app/src/main/java/com/example/uistateplayground/core/Result.kt
@@ -1,9 +1,14 @@
 package com.example.uistateplayground.core
 
+import java.io.IOException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.retryWhen
+
+private const val RETRY_TIME_IN_MILLIS = 15_000L
 
 sealed interface Result<out T> {
   data class Success<T>(val data: T) : Result<T>
@@ -17,5 +22,15 @@ fun <T> Flow<T>.asResult(): Flow<Result<T>> {
       Result.Success(it)
     }
     .onStart { emit(Result.Loading) }
+    .retryWhen { cause, _ ->
+      if (cause is IOException) {
+        emit(Result.Error(cause))
+
+        delay(RETRY_TIME_IN_MILLIS)
+        true
+      } else {
+        false
+      }
+    }
     .catch { emit(Result.Error(it)) }
 }


### PR DESCRIPTION
Today in my [project](https://github.com/krzdabrowski/android-starter-2022) that bases on your implementation in terms of offline-mode I've found a bug. Here are repro steps:

1. Have a clean app state (e.g. first launch)
2. Be in offline mode (e.g. airplane mode)
3. Launch app, error state will be shown which is fine.
4. However, no matter if user restores Internet connection later, you won't be able to see any data on screen (until you kill the app because network layer works fine).

This is due to the fact that when `.catch` catches an exception, whole flow will be cancelled and there is no way to collect newer data.
I know your solution is based on Now in Android repository but this bug is quite nasty so my proposal uses `retryWhen` operator, as described in [docs](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/retry-when.html).

Of course there are some other ways how to "re-collect" your streams but for me it seemed the most straightforward. So my PR is just a suggestion how to improve it 🙂 